### PR TITLE
支持IEntityTypeConfiguration配置

### DIFF
--- a/src/EFCore.Sharding/DbContext/DbModelFactory.cs
+++ b/src/EFCore.Sharding/DbContext/DbModelFactory.cs
@@ -85,6 +85,7 @@ namespace EFCore.Sharding
             {
                 modelBuilder.Model.AddEntityType(x);
             });
+            //支持IEntityTypeConfiguration配置
             modelBuilder.ApplyConfigurationsFromAssembly(_entityTypeMap.Values.First().Assembly);
             return modelBuilder.FinalizeModel();
         }

--- a/src/EFCore.Sharding/DbContext/DbModelFactory.cs
+++ b/src/EFCore.Sharding/DbContext/DbModelFactory.cs
@@ -85,7 +85,7 @@ namespace EFCore.Sharding
             {
                 modelBuilder.Model.AddEntityType(x);
             });
-
+            modelBuilder.ApplyConfigurationsFromAssembly(_entityTypeMap.Values.First().Assembly);
             return modelBuilder.FinalizeModel();
         }
 


### PR DESCRIPTION
特定的表要重写OnModelCreating
所以增加了IEntityTypeConfiguration配置支持
这样可以在Entity里增加OnModelCreating的配置
`
    public class pbpd_modelmaterialEntityTypeConfig : IEntityTypeConfiguration<pbpd_modelmaterial>
    {
        public void Configure(EntityTypeBuilder<pbpd_modelmaterial> builder)
        {
            builder
                .HasKey(t => new { t.MaterialId, t.ModelId });

            builder.HasOne(pt => pt.Material)
                .WithMany(p => p.ModelMaterials)
                .HasForeignKey(pt => pt.MaterialId);

            builder.HasOne(pt => pt.Model)
                .WithMany(p => p.ModelMaterials)
                .HasForeignKey(pt => pt.ModelId);
        }
    }
`