### PR TITLE
增加HasQueryFilter

### DIFF
--- a/src/EFCore.Sharding/DbContext/DbModelFactory.cs
+++ b/src/EFCore.Sharding/DbContext/DbModelFactory.cs
@@ -106,7 +106,7 @@ namespace EFCore.Sharding
                 // 如果不是做HasQueryFilter的话。Include不会过滤Deleted的数据
                 if (ShardingConfig.LogicDelete)
                 {
-                    if (entityTypeBuilder.Metadata.FindProperty(ShardingConfig.DeletedField) == null)
+                    if (entityTypeBuilder.Metadata.FindProperty(ShardingConfig.DeletedField) != null)
                     {
                         var exp = DynamicExpressionParser.ParseLambda(x, typeof(bool), $"{ShardingConfig.DeletedField} == @0", false);
                         entityTypeBuilder.HasQueryFilter(exp);


### PR DESCRIPTION
在BuildDbCompiledModel的时候，增加HasQueryFilter
做逻辑删除过滤
如果不加QueryFilter，
那么在Bussiness层做Include的时候，也会把Deleted的数据加载出来
this.GetIQueryable().Include(i => i.XXXX)

