### PR TITLE
获取类型时排除不能实例化的类型

### DIFF
--- a/src/EFCore.Sharding/Options/EFCoreShardingOptions.cs
+++ b/src/EFCore.Sharding/Options/EFCoreShardingOptions.cs
@@ -92,7 +92,9 @@ namespace EFCore.Sharding
                             {
                                 try
                                 {
-                                    types.AddRange(aAssembly.GetTypes());
+                                    types.AddRange(aAssembly.GetTypes()
+                                          .Where(p => p.GetConstructor(new Type[] { }) != null && p.GetConstructor(new Type[] { }).IsPublic)
+                                        );
                                 }
                                 catch
                                 {


### PR DESCRIPTION
在获取类型时会获取到所有程序集中的类型，本次提交移除了其中不能被实例化的类型，解决[issues#77](https://github.com/Coldairarrow/EFCore.Sharding/issues/77)的问题