### PR TITLE
efcore迁移移除逻辑表名直接替换成对应的sharding表名

### DIFF
--- a/src/EFCore.Sharding/Migrations/MigrationHelper.cs
+++ b/src/EFCore.Sharding/Migrations/MigrationHelper.cs
@@ -28,14 +28,19 @@ namespace EFCore.Sharding.Migrations
                 return;
             }
 
+            var migrationCommands = (List<MigrationCommand>)builder.GetGetFieldValue("_commands");
             addCmds.ForEach(aAddCmd =>
             {
                 var shardingCmds = BuildShardingCmds(operation, aAddCmd.CommandText, sqlGenerationHelper);
-                shardingCmds.ForEach(aShardingCmd =>
+                if (shardingCmds.Any())
                 {
-                    builder.Append(aShardingCmd)
-                        .EndCommand();
-                });
+                    migrationCommands.Remove(aAddCmd);
+                    shardingCmds.ForEach(aShardingCmd =>
+                    {
+                        builder.Append(aShardingCmd)
+                            .EndCommand();
+                    });
+                }
             });
         }
 


### PR DESCRIPTION
比如我有A表分表成A_1、A_2还会存在A表使用迁移所以为了解决这个bug进行对原cmd进行删除