### PR TITLE
修复定时器创建表时ServiceProvider被释放问题；在ShardingDbAccessor中释放内部IDbAccessor。

### DIFF
--- a/src/EFCore.Sharding/DependencyInjection/EFCoreShardingBootstrapper.cs
+++ b/src/EFCore.Sharding/DependencyInjection/EFCoreShardingBootstrapper.cs
@@ -42,7 +42,7 @@ namespace EFCore.Sharding
         /// <returns></returns>
         protected override Task ExecuteAsync(CancellationToken stoppingToken)
         {
-            using var scope = _serviceProvider.CreateScope();
+            var scope = _serviceProvider.CreateScope();
             EFCoreShardingOptions.Bootstrapper?.Invoke(scope.ServiceProvider);
 
             //长时间未释放监控,5分钟

--- a/src/EFCore.Sharding/Sharding/ShardingDbAccessor.cs
+++ b/src/EFCore.Sharding/Sharding/ShardingDbAccessor.cs
@@ -215,6 +215,7 @@ namespace EFCore.Sharding
             _disposed = true;
             _transaction?.Dispose();
             ClearDbs();
+            _db.Dispose();
         }
 
         #endregion


### PR DESCRIPTION
[修复定时器创建表时ServiceProvider被释放问题；在ShardingDbAccessor中释放内部IDbAccessor。]